### PR TITLE
Use torchvision read_image() directly rather than go through Pillow

### DIFF
--- a/src/mgds/pipelineModules/LoadImage.py
+++ b/src/mgds/pipelineModules/LoadImage.py
@@ -30,10 +30,11 @@ class LoadImage(
         self.dtype = dtype
 
         if channels == 3:
-            self.mode = 'RGB'
             self.mode = ImageReadMode.RGB
+            self.pillow_mode = 'RGB'
         elif channels == 1:
             self.mode = ImageReadMode.GRAY
+            self.pillow_mode = 'L'
         else:
             raise ValueError('Only 1 and 3 channels are supported.')
 
@@ -60,6 +61,10 @@ class LoadImage(
             image_tensor = image_tensor * (self.range_max - self.range_min) + self.range_min
         except FileNotFoundError:
             image_tensor = None
+        except RuntimeError:
+            # Torch builtins couldn't load it because not all image formats and
+            # variations there are supported. Fall back to pillow.
+            image_tensor = self._load_pillow(path)
         except:
             print("could not load image, it might be corrupted: " + path)
             raise
@@ -67,3 +72,27 @@ class LoadImage(
         return {
             self.image_out_name: image_tensor
         }
+
+    def _load_pillow(self, path):
+        """Fallback method to load the image through pillow.
+
+        MUCH slower, because the tensor transform holds the GIL.
+        """
+        try:
+            image = Image.open(path)
+            image = image.convert(self.pillow_mode)
+
+            t = transforms.ToTensor()
+            image_tensor = t(image).to(device=self.pipeline.device)
+
+            if self.dtype:
+                image_tensor = image_tensor.to(dtype=self.dtype)
+
+            image_tensor = image_tensor * (self.range_max - self.range_min) + self.range_min
+        except FileNotFoundError:
+            image_tensor = None
+        except:
+            print("could not load image, it might be corrupted: " + path)
+            raise
+
+        return image_tensor


### PR DESCRIPTION
Pillow conversion to Tensor holds the GIL, which forms a huge bottleneck in the multithreaded dataloader. Torchvision read_image() does not.

Torchvision read_image() also, afaict, does not rescale the image to 0-1 like Torchvision. Its output is always a uint8 datatype with a range of [0, 255]. So we perform the rescaling here.