### PR TITLE
fix: Re-enable regex for special tags

### DIFF
--- a/src/mgds/pipelineModules/DropTags.py
+++ b/src/mgds/pipelineModules/DropTags.py
@@ -72,18 +72,26 @@ class DropTags(
     #parse regex expressions, create new special list based on matches   
     def parse_regex(self, splist_in: list[str], taglist: list[str]) -> list[str]:
         splist_out = []
+        regex_spchars = set('.^$*+?{}[]|()\\')
 
         for pattern in splist_in:
-            try:
-                r = re.compile(pattern)
-            except re.error:
-                r = re.compile(re.escape(pattern))
+            regex = None
+
+            if any(c in regex_spchars for c in pattern):
+                try:
+                    regex = re.compile(pattern)
+                except re.error:
+                    regex = None
 
             for tag in taglist:
-                stripped_tag = tag.strip("()")
+                stripped = tag.strip("()")
 
-                if r.fullmatch(tag) or r.fullmatch(stripped_tag):
-                    splist_out.append(tag)
+                if regex:
+                    if regex.fullmatch(tag) or regex.fullmatch(stripped):
+                        splist_out.append(tag)
+                else:
+                    if pattern == tag or pattern == stripped:
+                        splist_out.append(tag)
 
         return splist_out
     

--- a/src/mgds/pipelineModules/DropTags.py
+++ b/src/mgds/pipelineModules/DropTags.py
@@ -72,17 +72,20 @@ class DropTags(
     #parse regex expressions, create new special list based on matches   
     def parse_regex(self, splist_in: list[str], taglist: list[str]) -> list[str]:
         splist_out = []
-        regex_spchars = set(".^$*+?!{}[]|()\\")
-        for c in splist_in:
-            if any((a in regex_spchars) for a in c):
-                pattern = re.escape(c)
+
+        for pattern in splist_in:
+            try:
                 r = re.compile(pattern)
-                for s in taglist:
-                    if r.fullmatch(s):
-                        splist_out.append(s)
-            else:
-                splist_out.append(c)
-        return splist_out   
+            except re.error:
+                r = re.compile(re.escape(pattern))
+
+            for tag in taglist:
+                stripped_tag = tag.strip("()")
+
+                if r.fullmatch(tag) or r.fullmatch(stripped_tag):
+                    splist_out.append(tag)
+
+        return splist_out
     
     #change probability evaluated against random() depending on mode
 


### PR DESCRIPTION
Restores proper regex handling in the parse_regex function after an unintended change that removed regex functionality. The previous fix incorrectly escaped all special_tags, treating them as literal strings only, which broke regex-based filtering.

Fixed:

- Restores regex handling: Special tags containing regex characters are compiled as regex patterns instead of being escaped.
- Ensures invalid regex patterns fallback to literals: If a regex fails to compile, it will be treated as a literal string instead of breaking the function.
- Keeps parentheses handling: Tags like "(photo)" are still matched when "photo.*" is used.

| **Special Tag** | **Tag List** | **Matches After Fix** |
|----------------|-------------|----------------------|
| `"apple"` | `["apple", "banana", "cherry", "orange", "grape"]` | `"apple"` |
| `"photo.*"` | `["photo", "photograph", "photon", "telephotography"]` | `"photo"`, `"photograph"`, `"photon"` |
| `"\d.*"` | `["1girl", "4kidz", "2001 a Space Odyssey", "dog"]` | `"1girl"`, `"4kidz"`, `"2001 a Space Odyssey"` |
| `"d.{1}g"` | `["dog", "dig", "dug", "drag", "domestic dog"]` | `"dog"`, `"dig"`, `"dug"` |
| `"Panic\! at the Disco holding \$100 bill"` | `["Panic! at the Disco holding $100 bill", "Panic at the Disco", "100 bill"]` | `"Panic! at the Disco holding $100 bill"` |
| `"dog("` (Invalid Regex) | `["dog(", "dog", "doghouse"]` | `"dog("` (Treated as Literal) |
| `"photo.*", "banana", "\d{3}"` | `["photo", "banana", "photon", "grape", "123", "dog"]` | `"photo"`, `"banana"`, `"photon"`, `"123"` |
| `"photo.*"` | `["photo", "photograph", "photo!", "daemon.large"]` | `"photo"`, `"photograph"`, `"photo!"` |
| `"daemon\.large"` | `["daemon.large", "daemon_large", "daemonAlarge"]` | `"daemon.large"` (Exact Match) |
| `"photo.*"` | `["photo", "(photo)", "(photograph)", "telephotography"]` | `"photo"`, `"(photo)"`, `"(photograph)"` |
