### PR TITLE
Multi-GPU support

### DIFF
--- a/src/mgds/MGDS.py
+++ b/src/mgds/MGDS.py
@@ -20,7 +20,7 @@ class MGDS(IterableDataset):
             concepts: list[dict],
             settings: dict,
             definition: [PipelineModule],
-            batch_size: int,
+            batch_size: int, #global batch size
             state: PipelineState,
             seed: int = 42,
             initial_epoch: int = 0,

--- a/src/mgds/MGDS.py
+++ b/src/mgds/MGDS.py
@@ -20,7 +20,7 @@ class MGDS(IterableDataset):
             concepts: list[dict],
             settings: dict,
             definition: [PipelineModule],
-            batch_size: int, #global batch size
+            batch_size: int, #local batch size
             state: PipelineState,
             seed: int = 42,
             initial_epoch: int = 0,

--- a/src/mgds/pipelineModules/DiskCache.py
+++ b/src/mgds/pipelineModules/DiskCache.py
@@ -218,7 +218,7 @@ class DiskCache(
 
                 if self.aggregate_cache[group_key][in_variation] is None:
                     self.aggregate_cache[group_key][in_variation] = \
-                        torch.load(os.path.realpath(os.path.join(cache_dir, 'aggregate.pt')), weights_only=False, map_location=this.pipeline.device)
+                        torch.load(os.path.realpath(os.path.join(cache_dir, 'aggregate.pt')), weights_only=False, map_location=self.pipeline.device)
 
     def __get_input_index(self, out_variation: int, out_index: int) -> tuple[str, int, int, int]:
         offset = 0
@@ -251,7 +251,7 @@ class DiskCache(
 
         elif requested_name in self.split_names:
             cache_path = os.path.join(self.__get_cache_dir(group_key, in_variation), str(group_index) + '.pt')
-            split_item = torch.load(os.path.realpath(cache_path), weights_only=False, map_location=this.pipeline.device)
+            split_item = torch.load(os.path.realpath(cache_path), weights_only=False, map_location=self.pipeline.device)
 
             for name in self.split_names:
                 item[name] = split_item[name]

--- a/src/mgds/pipelineModules/DiskCache.py
+++ b/src/mgds/pipelineModules/DiskCache.py
@@ -218,7 +218,7 @@ class DiskCache(
 
                 if self.aggregate_cache[group_key][in_variation] is None:
                     self.aggregate_cache[group_key][in_variation] = \
-                        torch.load(os.path.realpath(os.path.join(cache_dir, 'aggregate.pt')), weights_only=False)
+                        torch.load(os.path.realpath(os.path.join(cache_dir, 'aggregate.pt')), weights_only=False, map_location=this.pipeline.device)
 
     def __get_input_index(self, out_variation: int, out_index: int) -> tuple[str, int, int, int]:
         offset = 0
@@ -251,7 +251,7 @@ class DiskCache(
 
         elif requested_name in self.split_names:
             cache_path = os.path.join(self.__get_cache_dir(group_key, in_variation), str(group_index) + '.pt')
-            split_item = torch.load(os.path.realpath(cache_path), weights_only=False)
+            split_item = torch.load(os.path.realpath(cache_path), weights_only=False, map_location=this.pipeline.device)
 
             for name in self.split_names:
                 item[name] = split_item[name]

--- a/src/mgds/pipelineModules/DistributedSampler.py
+++ b/src/mgds/pipelineModules/DistributedSampler.py
@@ -1,0 +1,33 @@
+from mgds.PipelineModule import PipelineModule
+from mgds.pipelineModuleTypes.SingleVariationRandomAccessPipelineModule import SingleVariationRandomAccessPipelineModule
+
+
+class DistributedSampler(
+    PipelineModule,
+    SingleVariationRandomAccessPipelineModule,
+):
+    def __init__(self, names: [str], local_batch_size: int, world_size: int, rank: int):
+        super(DistributedSampler, self).__init__()
+        self.names = names
+        self.local_batch_size = local_batch_size
+        self.world_size = world_size
+        self.rank = rank
+
+
+    def length(self) -> int:
+        print(f"length input: {self._get_previous_length(self.names[0])}, length output: {self._get_previous_length(self.names[0]) // self.world_size}")
+        return self._get_previous_length(self.names[0]) // self.world_size
+
+    def get_inputs(self) -> list[str]:
+        return self.names
+
+    def get_outputs(self) -> list[str]:
+        return self.names
+
+    def get_item(self, index: int, requested_name: str = None) -> dict:
+        prev_index = (index * self.world_size) + self.rank
+        print(f"Distributed sampler, prev_index: {prev_index}, index: {index}")
+        item = {}
+        for name in self.names:
+            item[name] = self._get_previous_item(self.current_variation, name, prev_index)
+        return item

--- a/src/mgds/pipelineModules/DistributedSampler.py
+++ b/src/mgds/pipelineModules/DistributedSampler.py
@@ -6,10 +6,9 @@ class DistributedSampler(
     PipelineModule,
     SingleVariationRandomAccessPipelineModule,
 ):
-    def __init__(self, names: [str], local_batch_size: int, world_size: int, rank: int):
+    def __init__(self, names: [str], world_size: int, rank: int):
         super(DistributedSampler, self).__init__()
         self.names = names
-        self.local_batch_size = local_batch_size
         self.world_size = world_size
         self.rank = rank
 

--- a/src/mgds/pipelineModules/DistributedSampler.py
+++ b/src/mgds/pipelineModules/DistributedSampler.py
@@ -15,7 +15,6 @@ class DistributedSampler(
 
 
     def length(self) -> int:
-        print(f"length input: {self._get_previous_length(self.names[0])}, length output: {self._get_previous_length(self.names[0]) // self.world_size}")
         return self._get_previous_length(self.names[0]) // self.world_size
 
     def get_inputs(self) -> list[str]:

--- a/src/mgds/pipelineModules/DistributedSampler.py
+++ b/src/mgds/pipelineModules/DistributedSampler.py
@@ -26,7 +26,6 @@ class DistributedSampler(
 
     def get_item(self, index: int, requested_name: str = None) -> dict:
         prev_index = (index * self.world_size) + self.rank
-        print(f"Distributed sampler, prev_index: {prev_index}, index: {index}")
         item = {}
         for name in self.names:
             item[name] = self._get_previous_item(self.current_variation, name, prev_index)


### PR DESCRIPTION
 - adds a simple pipeline module that distributes batches among GPUs, by skipping batches that are not intended for the current GPU
 - fixes an issue with torch.load:
   torch.save saves the torch device of the tensor. torch.load later tries to load it into the same device, unless mapped to the current one

doesn't do anything more than that - specifically:

- not thread-safe (and doesn't have to be for multi-GPU)
- doesn't synchronize disk cache. The code to avoid concurrent writes to the disk cache is in OneTrainer