### PR TITLE
EncodeMistralText: move tokens to text_encoder.device before forward

### DIFF
--- a/src/mgds/pipelineModules/EncodeMistralText.py
+++ b/src/mgds/pipelineModules/EncodeMistralText.py
@@ -51,6 +51,15 @@ class EncodeMistralText(
         else:
             tokens_attention_mask = None
 
+        # Match inputs to the text encoder's device. Upstream pipeline stages
+        # typically land tokens on cuda:0; for model-parallel setups that keep
+        # Mistral-24B on CPU (a single 32 GB consumer card can't fit ~48 GB bf16),
+        # the forward call would otherwise fail with a device-mismatch error.
+        te_device = self.text_encoder.device
+        tokens = tokens.to(te_device)
+        if tokens_attention_mask is not None:
+            tokens_attention_mask = tokens_attention_mask.to(te_device)
+
         with self._all_contexts(self.autocast_contexts):
             text_encoder_output = self.text_encoder(
                 tokens,


### PR DESCRIPTION
## Summary

`EncodeMistralText.get_item` now moves `tokens` and `attention_mask` to `self.text_encoder.device` before the forward call. One-line fix (counting the device move + the existing-mask guard).

## Why

Upstream pipeline stages land `tokens` on `cuda:0` by default. When the Mistral text encoder is hosted on CPU — for example, on model-parallel setups where a single 32 GB consumer card can't fit Mistral-3-Small-24B's ~48 GB bf16 footprint — the existing forward call dies with:

```
RuntimeError: Expected all tensors to be on the same device, but found at
least two devices, cuda:0 and cpu! (when checking argument for argument index
in method wrapper_CUDA__index_select)
```

`.to(device)` is a no-op when the tensor is already on that device, so the single-GPU happy-path is unaffected.

## Where this came up

Building a dual-GPU model-parallel FLUX.2 LoRA training path for OneTrainer on 2× RTX 5090 — the Mistral TE has to stay on CPU because neither GPU can fit half the FLUX.2 transformer *and* the TE. With the TE on CPU, `EncodeMistralText.get_item` is the last device-mismatch bug before the forward succeeds. Full context: https://github.com/genno-whittlery/flux2-dual-gpu-lora (OneTrainer port section); paired with https://github.com/Nerogar/OneTrainer/pull/1450.

## Test plan
- [x] OneTrainer dual-GPU FLUX.2 LoRA run on 2× RTX 5090 with Mistral TE on CPU — forward succeeds, full 32-step training epoch completes
- [x] Single-GPU OneTrainer FLUX.2 run unchanged (`.to(te_device)` is no-op when devices match)