### PR TITLE
Bring mgds to OneTrainer code standards

### DIFF
--- a/src/mgds/MGDS.py
+++ b/src/mgds/MGDS.py
@@ -1,7 +1,7 @@
 import random
 
 import torch
-from torch.utils.data import DataLoader, Dataset, IterableDataset
+from torch.utils.data import DataLoader, IterableDataset
 
 from mgds.ConceptPipelineModule import ConceptPipelineModule
 from mgds.LoadingPipeline import LoadingPipeline
@@ -19,7 +19,7 @@ class MGDS(IterableDataset):
             device: torch.device,
             concepts: list[dict],
             settings: dict,
-            definition: [PipelineModule],
+            definition: list[PipelineModule],
             batch_size: int, #local batch size
             state: PipelineState,
             seed: int = 42,

--- a/src/mgds/PipelineModule.py
+++ b/src/mgds/PipelineModule.py
@@ -4,12 +4,16 @@ from abc import ABCMeta, abstractmethod
 from concurrent import futures
 from contextlib import ExitStack
 from random import Random
+from typing import TYPE_CHECKING
 
 import torch
 
 from mgds.pipelineModuleTypes.RandomAccessPipelineModule import RandomAccessPipelineModule
 from mgds.pipelineModuleTypes.SerialPipelineModule import SerialPipelineModule
 from mgds.pipelineModuleTypes.SingleVariationRandomAccessPipelineModule import SingleVariationRandomAccessPipelineModule
+
+if TYPE_CHECKING:
+    from mgds.LoadingPipeline import LoadingPipeline
 
 
 class PipelineState:

--- a/src/mgds/PipelineModule.py
+++ b/src/mgds/PipelineModule.py
@@ -146,7 +146,6 @@ class PipelineModule(metaclass=ABCMeta):
     def _get_previous_length(self, name: str):
         split_name = name.split('.')
         item_name = split_name[0]
-        path_names = split_name[1::]
 
         for previous_module_index in range(self.__module_index - 1, -1, -1):
             module = self.pipeline.modules[previous_module_index]

--- a/src/mgds/pipelineModules/DropTags.py
+++ b/src/mgds/pipelineModules/DropTags.py
@@ -144,7 +144,7 @@ class DropTags(
                 for s in dropout_tags:
                     if special_tag_mode == "WHITELIST" and s in special_tags_list:
                         pruned_tags.append(s)
-                    elif special_tag_mode == "BLACKLIST" and not(s in special_tags_list):
+                    elif special_tag_mode == "BLACKLIST" and s not in special_tags_list:
                         pruned_tags.append(s)
             elif dropout_mode.startswith("RANDOM"):     
                 #iterate through dropout_tags and add to pruned_tags if random > probability
@@ -156,7 +156,7 @@ class DropTags(
                 elif special_tag_mode == "BLACKLIST":
                     for i, s in enumerate(dropout_tags):
                         if rand.random() > self.probability_weighted(probability, dropout_mode, i, len(dropout_tags)) \
-                        or not(s in special_tags_list):
+                        or s not in special_tags_list:
                             pruned_tags.append(s)
                 else:   #NONE or any other unexpected values
                     for i, s in enumerate(dropout_tags):

--- a/src/mgds/pipelineModules/ImageToVideo.py
+++ b/src/mgds/pipelineModules/ImageToVideo.py
@@ -1,5 +1,3 @@
-from transformers import CLIPTokenizer, T5Tokenizer, T5TokenizerFast, GemmaTokenizer, LlamaTokenizer
-
 from mgds.PipelineModule import PipelineModule
 from mgds.pipelineModuleTypes.RandomAccessPipelineModule import RandomAccessPipelineModule
 

--- a/src/mgds/pipelineModules/LoadVideo.py
+++ b/src/mgds/pipelineModules/LoadVideo.py
@@ -123,7 +123,7 @@ class LoadVideo(
 
             except FileNotFoundError:
                 video_tensor = None
-            except Exception as e:
+            except Exception:
                 print("could not load video, it might be corrupted: " + path)
                 raise
         else:


### PR DESCRIPTION
Small cleanup pass to align mgds with the lint/type-check standards used in OneTrainer:

- Resolve `LoadingPipeline` forward reference in `PipelineModule` via `TYPE_CHECKING` import (was unresolvable to type checkers and would `NameError` under `typing.get_type_hints()`).
- Fix `MGDS.__init__` annotation `definition: [PipelineModule]` → `list[PipelineModule]` (the list literal is not a valid type).
- Clear all `ruff check` violations: unused imports (`MGDS`, `ImageToVideo`), `not(x in y)` → `x not in y` (`DropTags`), unused `as e` on a re-raised exception (`LoadVideo`), and an unused `path_names` local (`PipelineModule`).

Pure cleanup — no behavior changes.